### PR TITLE
Expo 584 mejorar responsiveness mobile

### DIFF
--- a/src/components/event/individual/SearchTickets.tsx
+++ b/src/components/event/individual/SearchTickets.tsx
@@ -23,6 +23,13 @@ export function SearchTickets({
 }: SearchTicketsProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const prevExternalValue = useRef<string | undefined>(undefined);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (window.innerWidth >= 768) {
+      inputRef.current?.focus();
+    }
+  }, []);
 
   // Filter tickets based on search term
   const filteredTickets = useMemo(() => {
@@ -78,11 +85,11 @@ export function SearchTickets({
       <div className='relative max-w-md mx-auto'>
         <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4' />
         <Input
+          ref={inputRef}
           placeholder='Buscar por nombre, DNI, email, teléfono u organizador...'
           value={searchTerm}
           onChange={(e) => handleSearchChange(e.target.value)}
           className='pl-10'
-          autoFocus={true}
         />
       </div>
     </div>

--- a/src/components/event/individual/TicketTableWithTabs.tsx
+++ b/src/components/event/individual/TicketTableWithTabs.tsx
@@ -123,12 +123,15 @@ export function TicketTableWithTabs({
         <TabsList className='flex-1 w-full md:max-w-[98%] max-w-[98%] mx-auto overflow-x-auto [scrollbar-width:thin] justify-start'>
           {Object.keys(ticketsByType).map((type) => (
             <TabsTrigger
-              className='min-w-2xs max-w-xs px-4'
+              className='md:min-w-2xs max-w-xs px-4'
               key={type}
               value={type}
             >
               <span className='truncate' title={type}>
-                {type}
+                <span className='md:hidden'>
+                  {type.length > 16 ? `${type.slice(0, 16)}…` : type}
+                </span>
+                <span className='hidden md:inline'>{type}</span>
               </span>
             </TabsTrigger>
           ))}

--- a/src/components/event/individual/ticketsTable/Pagination.tsx
+++ b/src/components/event/individual/ticketsTable/Pagination.tsx
@@ -79,7 +79,7 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
   return (
     <>
       <div className='border-t border-accent-dark/10 bg-transparent px-3 py-3 text-black sm:px-6'>
-        <div className='flex items-center justify-between'>
+        <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
           <div
             id='buttons-pagination'
             className='flex items-center justify-center gap-x-2 px-2'
@@ -105,9 +105,7 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
               <strong className='text-sm sm:text-base'>
                 {noData
                   ? '0 de 0'
-                  : `${table.getState().pagination.pageIndex + 1} de ${table
-                      .getPageCount()
-                      .toLocaleString()}`}
+                  : `${table.getState().pagination.pageIndex + 1} de ${table.getPageCount().toLocaleString()}`}
               </strong>
             </span>
             <Button
@@ -126,7 +124,7 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
             >
               <ChevronsRight className='w-6' />
             </Button>
-            <span className='flex items-center gap-1 text-sm sm:text-base'>
+            <span className='hidden items-center gap-1 text-sm sm:flex sm:text-base'>
               {noData
                 ? '0-0 de 0'
                 : `${firstRow.toLocaleString()}-${lastRow.toLocaleString()} de ${totalRows.toLocaleString()}`}
@@ -146,24 +144,31 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
               className='w-14 rounded-md border text-center text-black'
             />
           </span>
-          <select
-            value={table.getState().pagination.pageSize}
-            onChange={(e) => {
-              const size = Number(e.target.value);
-              table.setPageSize(size);
-            }}
-            className='rounded border bg-white/90 p-1 text-sm sm:text-base'
-          >
-            {[2, 5, 10, 15, 20].map((pageSize) => (
-              <option
-                className='text-sm sm:text-base'
-                key={pageSize}
-                value={pageSize}
-              >
-                Mostrar {pageSize}
-              </option>
-            ))}
-          </select>
+          <div className='flex items-center justify-center gap-x-3 sm:justify-end'>
+            <span className='flex items-center gap-1 text-sm sm:hidden'>
+              {noData
+                ? '0-0 de 0'
+                : `${firstRow.toLocaleString()}-${lastRow.toLocaleString()} de ${totalRows.toLocaleString()}`}
+            </span>
+            <select
+              value={table.getState().pagination.pageSize}
+              onChange={(e) => {
+                const size = Number(e.target.value);
+                table.setPageSize(size);
+              }}
+              className='rounded border bg-white/90 p-1 text-sm sm:text-base'
+            >
+              {[2, 5, 10, 15, 20].map((pageSize) => (
+                <option
+                  className='text-sm sm:text-base'
+                  key={pageSize}
+                  value={pageSize}
+                >
+                  Mostrar {pageSize}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
       </div>
     </>

--- a/src/components/event/individual/ticketsTable/Pagination.tsx
+++ b/src/components/event/individual/ticketsTable/Pagination.tsx
@@ -144,7 +144,7 @@ export function Pagination<TData>({ table }: PaginationProps<TData>) {
               className='w-14 rounded-md border text-center text-black'
             />
           </span>
-          <div className='flex items-center justify-center gap-x-3 sm:justify-end'>
+          <div className='flex items-center justify-between gap-x-3 px-2 sm:justify-end sm:px-0'>
             <span className='flex items-center gap-1 text-sm sm:hidden'>
               {noData
                 ? '0-0 de 0'


### PR DESCRIPTION
- Eliminación del autofocus de `<SearchTickets/>` en mobile desde evento particular

| Antes | Después |
| ------------- | ------------- |
| <img width="408" height="371" alt="image" src="https://github.com/user-attachments/assets/7e88e7fb-92d9-44ca-8d22-9d50759a7179" />  | <img width="408" height="380" alt="image" src="https://github.com/user-attachments/assets/05482986-19f2-4e1a-b92f-736ec110670d" />  |

