### PR TITLE
Expose signed calendar events endpoint

### DIFF
--- a/src/app/api/credentials/status/route.ts
+++ b/src/app/api/credentials/status/route.ts
@@ -1,14 +1,6 @@
-import { createHmac } from 'crypto';
-
 import { NextResponse } from 'next/server';
 
-function signPayload(timestamp: string, rawBody: string) {
-  const signingSecret = process.env.CREDENTIALS_SIGNING_SECRET?.trim();
-  if (!signingSecret) return null;
-  return createHmac('sha256', signingSecret)
-    .update(`${timestamp}.${rawBody}`)
-    .digest('hex');
-}
+import { signPayload } from '@/server/security/signed-request';
 
 export async function GET() {
   if (!process.env.INSTANCE_WEB_URL) {

--- a/src/app/api/pluto/calendar-events/route.ts
+++ b/src/app/api/pluto/calendar-events/route.ts
@@ -1,0 +1,115 @@
+import { asc, and, eq, gte, lte } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { db } from '@/drizzle';
+
+import { event, location } from '@/drizzle/schema';
+import { verifySignedRequest } from '@/server/security/signed-request';
+import { getCalendarStatsByEventId } from '@/server/services/calendarEventStats';
+
+const calendarEventsRequestSchema = z
+  .object({
+    from: z.iso.datetime({ offset: true }),
+    to: z.iso.datetime({ offset: true }),
+  })
+  .refine((value) => new Date(value.from) <= new Date(value.to), {
+    message: 'from must be before or equal to to',
+    path: ['from'],
+  });
+
+function getInstanceUrl() {
+  const rawUrl = process.env.INSTANCE_WEB_URL?.trim();
+  if (!rawUrl) return '';
+  return rawUrl.startsWith('http') ? rawUrl : `https://${rawUrl}`;
+}
+
+function toIsoDateTime(value: string) {
+  return new Date(value).toISOString();
+}
+
+export async function POST(request: Request) {
+  const signedRequest = await verifySignedRequest(request, {
+    logPrefix: '[api/pluto/calendar-events]',
+  });
+
+  if (!signedRequest.ok) {
+    return signedRequest.response;
+  }
+
+  let body: z.infer<typeof calendarEventsRequestSchema>;
+  try {
+    body = calendarEventsRequestSchema.parse(JSON.parse(signedRequest.rawBody));
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'BAD_REQUEST', message: 'Body inválido.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const events = await db
+      .select({
+        id: event.id,
+        slug: event.slug,
+        name: event.name,
+        startingDate: event.startingDate,
+        endingDate: event.endingDate,
+        coverImageUrl: event.coverImageUrl,
+        locationName: location.name,
+        locationAddress: location.address,
+      })
+      .from(event)
+      .innerJoin(location, eq(location.id, event.locationId))
+      .where(
+        and(
+          eq(event.isActive, true),
+          eq(event.isDeleted, false),
+          lte(event.startingDate, body.to),
+          gte(event.endingDate, body.from),
+        ),
+      )
+      .orderBy(asc(event.startingDate));
+
+    const eventStats = new Map(
+      await Promise.all(
+        events.map(
+          async (eventItem) =>
+            [
+              eventItem.id,
+              await getCalendarStatsByEventId(eventItem.id),
+            ] as const,
+        ),
+      ),
+    );
+
+    return NextResponse.json({
+      success: true,
+      instance: {
+        name: process.env.NEXT_PUBLIC_INSTANCE_NAME ?? 'Planeta Nocturno',
+        url: getInstanceUrl(),
+      },
+      events: events.map((eventItem) => ({
+        id: eventItem.id,
+        slug: eventItem.slug,
+        name: eventItem.name,
+        startingDate: toIsoDateTime(eventItem.startingDate),
+        endingDate: toIsoDateTime(eventItem.endingDate),
+        locationName: eventItem.locationName,
+        locationAddress: eventItem.locationAddress,
+        coverImageUrl: eventItem.coverImageUrl,
+        stats: eventStats.get(eventItem.id),
+      })),
+    });
+  } catch (error) {
+    console.error('[api/pluto/calendar-events] Unable to fetch events', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'DATA_UNAVAILABLE',
+        message: 'No pudimos obtener los eventos de esta instancia.',
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/pluto/calendar-events/route.ts
+++ b/src/app/api/pluto/calendar-events/route.ts
@@ -71,17 +71,13 @@ export async function POST(request: Request) {
       )
       .orderBy(asc(event.startingDate));
 
-    const eventStats = new Map(
-      await Promise.all(
-        events.map(
-          async (eventItem) =>
-            [
-              eventItem.id,
-              await getCalendarStatsByEventId(eventItem.id),
-            ] as const,
-        ),
-      ),
-    );
+    const eventStats = new Map();
+    for (const eventItem of events) {
+      eventStats.set(
+        eventItem.id,
+        await getCalendarStatsByEventId(eventItem.id),
+      );
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/credentials/action.ts
+++ b/src/app/credentials/action.ts
@@ -1,23 +1,14 @@
 'use server';
 
-import { createHmac } from 'crypto';
-
 import { type Route } from 'next';
 import { redirect } from 'next/navigation';
 
 import { auth } from '@/server/auth';
+import { signPayload } from '@/server/security/signed-request';
 import { getDefaultPathByRole } from '@/server/utils/authRedirect';
 
 const MP_ACCESS_TOKEN_RE = /^APP_USR-\d+-\d+-[A-Za-z0-9]+-\d+$/;
 const MP_SECRET_KEY_RE = /^[a-fA-F0-9]{64}$/;
-
-function signPayload(timestamp: string, rawBody: string) {
-  const signingSecret = process.env.CREDENTIALS_SIGNING_SECRET?.trim();
-  if (!signingSecret) return null;
-  return createHmac('sha256', signingSecret)
-    .update(`${timestamp}.${rawBody}`)
-    .digest('hex');
-}
 
 export async function saveCredentials(formData: FormData) {
   const session = await auth();

--- a/src/server/routers/statistics.ts
+++ b/src/server/routers/statistics.ts
@@ -3,6 +3,7 @@ import { and, between, eq, gte, lte, ne } from 'drizzle-orm';
 import z from 'zod';
 
 import { emittedTicket, event, ticketGroup } from '@/drizzle/schema';
+import { calculateTicketGroupStats } from '@/server/services/eventStats';
 import { adminProcedure, router } from '@/server/trpc';
 
 export const statisticsRouter = router({
@@ -52,57 +53,15 @@ export const statisticsRouter = router({
         },
       });
 
-      // Total raised & sold per ticketType per ticketGroup (ttpg: ticketTypePerGroups)
-      const { totalRaised, totalSold } = data
-        .flatMap((ticketGroup) => ticketGroup.ticketTypePerGroups)
-        .reduce(
-          (acc, ttpg) => {
-            const price = ttpg.ticketType?.price ?? 0;
-            const amount = ttpg.amount ?? 0;
-
-            acc.totalRaised += amount * price;
-            acc.totalSold += amount;
-
-            return acc;
-          },
-          { totalRaised: 0, totalSold: 0 },
-        );
-
-      // Asistencia
-      const allTickets = data.flatMap((tg) => tg.emittedTickets);
-      const { totalTickets, totalScanned } = allTickets.reduce(
-        (acc, ticket) => {
-          acc.totalTickets++;
-          if (ticket.scanned) {
-            acc.totalScanned++;
-          }
-
-          return acc;
-        },
-        { totalTickets: 0, totalScanned: 0 },
-      );
-      const scannedPercentage =
-        totalTickets > 0 ? (totalScanned / totalTickets) * 100 : 0;
-
-      // Asistencia por genero y por hora
-      const genderCounts: Record<string, number> = {};
-
-      for (const ticket of allTickets) {
-        if (!ticket.scanned) continue;
-        const gender = ticket.gender;
-        if (!genderCounts[gender]) {
-          genderCounts[gender] = 0;
-        }
-        genderCounts[gender]++;
-      }
+      const stats = calculateTicketGroupStats(data);
 
       return {
-        totalRaised,
-        totalSold,
-        totalTickets,
-        totalScanned,
-        scannedPercentage,
-        genderCounts,
+        totalRaised: stats.totalRaised,
+        totalSold: stats.totalSold,
+        totalTickets: stats.totalTickets,
+        totalScanned: stats.totalScanned,
+        scannedPercentage: stats.scannedPercentage,
+        genderCounts: stats.genderCounts,
       };
     }),
   getEventsStats: adminProcedure
@@ -147,37 +106,15 @@ export const statisticsRouter = router({
       });
 
       const stats = data.map((e) => {
-        const { totalRaised, totalSold } = e.ticketGroups
-          .flatMap((ticketGroup) => ticketGroup.ticketTypePerGroups)
-          .reduce(
-            (acc, ttpg) => {
-              const price = ttpg.ticketType?.price ?? 0;
-              const amount = ttpg.amount ?? 0;
-
-              acc.totalRaised += amount * price;
-              acc.totalSold += amount;
-
-              return acc;
-            },
-            { totalRaised: 0, totalSold: 0 },
-          );
-        const allEt = e.ticketGroups.flatMap((tg) =>
-          tg.emittedTickets.map((et) => et.scanned),
-        );
-        const attendance = allEt.filter((et) => et).length;
-
-        const amountEt = e.ticketGroups.reduce((acc, tg) => {
-          acc += tg.emittedTickets.length;
-          return acc;
-        }, 0);
+        const stats = calculateTicketGroupStats(e.ticketGroups);
 
         return {
           id: e.id,
           name: e.name,
-          attendance,
-          totalRaised,
-          totalSold,
-          totalEmitted: amountEt,
+          attendance: stats.totalScanned,
+          totalRaised: stats.totalRaised,
+          totalSold: stats.totalSold,
+          totalEmitted: stats.totalTickets,
         };
       });
 
@@ -228,40 +165,17 @@ export const statisticsRouter = router({
       });
 
       const stats = data.map((l) => {
-        const { totalRaised, totalSold } = l.events
-          .flatMap((e) => e.ticketGroups)
-          .flatMap((ticketGroup) => ticketGroup.ticketTypePerGroups)
-          .reduce(
-            (acc, ttpg) => {
-              const price = ttpg.ticketType?.price ?? 0;
-              const amount = ttpg.amount ?? 0;
-
-              acc.totalRaised += amount * price;
-              acc.totalSold += amount;
-
-              return acc;
-            },
-            { totalRaised: 0, totalSold: 0 },
-          );
-        const allEt = l.events
-          .flatMap((e) => e.ticketGroups)
-          .flatMap((tg) => tg.emittedTickets.map((et) => et.scanned));
-        const attendance = allEt.filter((et) => et).length;
-
-        const amountEt = l.events
-          .flatMap((e) => e.ticketGroups)
-          .reduce((acc, tg) => {
-            acc += tg.emittedTickets.length;
-            return acc;
-          }, 0);
+        const stats = calculateTicketGroupStats(
+          l.events.flatMap((e) => e.ticketGroups),
+        );
 
         return {
           id: l.id,
           name: l.name,
-          attendance,
-          totalRaised,
-          totalSold,
-          totalEmitted: amountEt,
+          attendance: stats.totalScanned,
+          totalRaised: stats.totalRaised,
+          totalSold: stats.totalSold,
+          totalEmitted: stats.totalTickets,
         };
       });
 

--- a/src/server/security/signed-request.ts
+++ b/src/server/security/signed-request.ts
@@ -1,0 +1,121 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+import { NextResponse } from 'next/server';
+
+const DEFAULT_SIGNATURE_TOLERANCE_MS = 5 * 60 * 1000;
+
+function unauthorizedResponse() {
+  return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 });
+}
+
+function normalizeTimestamp(value: string): number | null {
+  const raw = Number(value);
+  if (!Number.isFinite(raw)) return null;
+  return raw < 1_000_000_000_000 ? raw * 1000 : raw;
+}
+
+function isValidSignature(
+  signingSecret: string,
+  timestamp: string,
+  rawBody: string,
+  signatureHeader: string,
+) {
+  const expected = createHmac('sha256', signingSecret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+
+  const received = signatureHeader.startsWith('sha256=')
+    ? signatureHeader.slice('sha256='.length)
+    : signatureHeader;
+
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  const receivedBuffer = Buffer.from(received, 'hex');
+
+  if (expectedBuffer.length !== receivedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, receivedBuffer);
+}
+
+export function signPayload(
+  timestamp: string,
+  rawBody: string,
+  signingSecret = process.env.CREDENTIALS_SIGNING_SECRET?.trim(),
+) {
+  if (!signingSecret) return null;
+
+  return createHmac('sha256', signingSecret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+}
+
+type VerifySignedRequestOptions = {
+  logPrefix: string;
+  toleranceMs?: number;
+};
+
+type VerifySignedRequestResult =
+  | {
+      ok: true;
+      rawBody: string;
+    }
+  | {
+      ok: false;
+      response: NextResponse;
+    };
+
+export async function verifySignedRequest(
+  request: Request,
+  options: VerifySignedRequestOptions,
+): Promise<VerifySignedRequestResult> {
+  const { logPrefix, toleranceMs = DEFAULT_SIGNATURE_TOLERANCE_MS } = options;
+  const signingSecret = process.env.CREDENTIALS_SIGNING_SECRET?.trim();
+
+  if (!signingSecret) {
+    console.error(`${logPrefix} Missing CREDENTIALS_SIGNING_SECRET`);
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: 'CREDENTIALS_SIGNING_SECRET is not configured' },
+        { status: 500 },
+      ),
+    };
+  }
+
+  const signatureHeader = request.headers.get('x-signature')?.trim();
+  const timestampHeader = request.headers.get('x-timestamp')?.trim();
+
+  if (!signatureHeader || !timestampHeader) {
+    console.warn(`${logPrefix} Missing signature or timestamp header`);
+    return { ok: false, response: unauthorizedResponse() };
+  }
+
+  const normalizedTimestamp = normalizeTimestamp(timestampHeader);
+  if (!normalizedTimestamp) {
+    console.warn(`${logPrefix} Invalid timestamp format`, {
+      timestampHeader,
+    });
+    return { ok: false, response: unauthorizedResponse() };
+  }
+
+  if (Math.abs(Date.now() - normalizedTimestamp) > toleranceMs) {
+    console.warn(`${logPrefix} Timestamp outside tolerance window`, {
+      timestampHeader,
+      normalizedTimestamp,
+    });
+    return { ok: false, response: unauthorizedResponse() };
+  }
+
+  const rawBody = await request.text();
+  if (
+    !isValidSignature(signingSecret, timestampHeader, rawBody, signatureHeader)
+  ) {
+    console.warn(`${logPrefix} Invalid HMAC signature`, {
+      timestampHeader,
+    });
+    return { ok: false, response: unauthorizedResponse() };
+  }
+
+  return { ok: true, rawBody };
+}

--- a/src/server/services/calendarEventStats.ts
+++ b/src/server/services/calendarEventStats.ts
@@ -1,0 +1,50 @@
+import { and, eq, ne, sql } from 'drizzle-orm';
+
+import { db } from '@/drizzle';
+
+import {
+  emittedTicket,
+  ticketGroup,
+  ticketType,
+  ticketTypePerGroup,
+} from '@/drizzle/schema';
+
+export async function getCalendarStatsByEventId(eventId: string) {
+  const [salesStats] = await db
+    .select({
+      ticketsSold: sql<number>`coalesce(sum(${ticketTypePerGroup.amount}), 0)`,
+      totalRaised: sql<number>`coalesce(sum(${ticketTypePerGroup.amount} * coalesce(${ticketType.price}, 0)), 0)`,
+    })
+    .from(ticketTypePerGroup)
+    .innerJoin(
+      ticketGroup,
+      eq(ticketGroup.id, ticketTypePerGroup.ticketGroupId),
+    )
+    .innerJoin(ticketType, eq(ticketType.id, ticketTypePerGroup.ticketTypeId))
+    .where(
+      and(eq(ticketGroup.eventId, eventId), ne(ticketGroup.status, 'BOOKED')),
+    );
+
+  const [attendanceStats] = await db
+    .select({
+      ticketsIssued: sql<number>`count(${emittedTicket.id})`,
+      ticketsScanned: sql<number>`coalesce(sum(case when ${emittedTicket.scanned} then 1 else 0 end), 0)`,
+    })
+    .from(emittedTicket)
+    .innerJoin(ticketGroup, eq(ticketGroup.id, emittedTicket.ticketGroupId))
+    .where(
+      and(eq(ticketGroup.eventId, eventId), ne(ticketGroup.status, 'BOOKED')),
+    );
+
+  const ticketsIssued = Number(attendanceStats?.ticketsIssued ?? 0);
+  const ticketsScanned = Number(attendanceStats?.ticketsScanned ?? 0);
+
+  return {
+    ticketsSold: Number(salesStats?.ticketsSold ?? 0),
+    ticketsIssued,
+    ticketsScanned,
+    attendanceRate:
+      ticketsIssued > 0 ? (ticketsScanned / ticketsIssued) * 100 : 0,
+    totalRaised: Number(salesStats?.totalRaised ?? 0),
+  };
+}

--- a/src/server/services/eventStats.ts
+++ b/src/server/services/eventStats.ts
@@ -1,0 +1,72 @@
+type TicketGroupForStats = {
+  ticketTypePerGroups: {
+    amount: number | null;
+    ticketType: {
+      price: number | null;
+    } | null;
+  }[];
+  emittedTickets: {
+    scanned: boolean;
+    gender?: string | null;
+  }[];
+};
+
+export function calculateTicketGroupStats(ticketGroups: TicketGroupForStats[]) {
+  const { totalRaised, totalSold } = ticketGroups
+    .flatMap((ticketGroup) => ticketGroup.ticketTypePerGroups)
+    .reduce(
+      (acc, ttpg) => {
+        const price = ttpg.ticketType?.price ?? 0;
+        const amount = ttpg.amount ?? 0;
+
+        acc.totalRaised += amount * price;
+        acc.totalSold += amount;
+
+        return acc;
+      },
+      { totalRaised: 0, totalSold: 0 },
+    );
+
+  const allTickets = ticketGroups.flatMap((tg) => tg.emittedTickets);
+  const { totalTickets, totalScanned } = allTickets.reduce(
+    (acc, ticket) => {
+      acc.totalTickets++;
+      if (ticket.scanned) {
+        acc.totalScanned++;
+      }
+
+      return acc;
+    },
+    { totalTickets: 0, totalScanned: 0 },
+  );
+
+  const genderCounts: Record<string, number> = {};
+  for (const ticket of allTickets) {
+    if (!ticket.scanned || !ticket.gender) continue;
+    genderCounts[ticket.gender] = (genderCounts[ticket.gender] ?? 0) + 1;
+  }
+
+  return {
+    totalRaised,
+    totalSold,
+    totalTickets,
+    totalScanned,
+    scannedPercentage:
+      totalTickets > 0 ? (totalScanned / totalTickets) * 100 : 0,
+    genderCounts,
+  };
+}
+
+export function calculateCalendarEventStats(
+  ticketGroups: TicketGroupForStats[],
+) {
+  const stats = calculateTicketGroupStats(ticketGroups);
+
+  return {
+    ticketsSold: stats.totalSold,
+    ticketsIssued: stats.totalTickets,
+    ticketsScanned: stats.totalScanned,
+    attendanceRate: stats.scannedPercentage,
+    totalRaised: stats.totalRaised,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds signed POST /api/pluto/calendar-events for Pluto to read active event calendar data from each PN instance
- Extracts reusable signed request helpers and event stat calculation helpers
- Returns event metadata, ISO dates, location, cover image, and sold/issued/scanned/revenue stats while excluding BOOKED ticket groups

## Validation
- npx tsc --noEmit
- npx eslint src/app/api/pluto/calendar-events/route.ts src/server/services/calendarEventStats.ts src/server/security/signed-request.ts src/server/services/eventStats.ts src/server/routers/statistics.ts src/app/credentials/action.ts src/app/api/credentials/status/route.ts
- Manual signed endpoint checks against test DB: valid 200, missing/invalid/expired signature 401, invalid body 400